### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1160,7 +1160,7 @@ PHP CodeSniffer состоит из двух скриптов; главный `p
 
 Полезные ссылки:
 
-* [CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+* [CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 
 ### Psalm
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932